### PR TITLE
Removed characters that PTC accounts don't use on login

### DIFF
--- a/src/pallettown/RandomDetails.java
+++ b/src/pallettown/RandomDetails.java
@@ -26,7 +26,7 @@ public class RandomDetails {
     };
 
     public static final char[] SYMBOLS = new char[]{
-        '#','!','@','$','%','&','*','(',')','[',']','{','}'
+        '#','!','@','$','%','&','*','(',')'
     };
 
     static String randomBirthday() {


### PR DESCRIPTION
Removed { } [ ] from the account creation, for every account using these characters can not log in.  While accepted on account creation, they aren't accepted at account login.